### PR TITLE
Add entity -> file relationship to the Neo4j graph

### DIFF
--- a/pub_ingest.ipynb
+++ b/pub_ingest.ipynb
@@ -144,7 +144,7 @@
     "    MERGE (f:File {path: $file_path})\n",
     "    SET f.name = $file_name, \n",
     "        f.type = $file_type,\n",
-    "        f.length = $file_length\n",
+    "        f.length = $file_length,\n",
     "        f.system = $file_system,\n",
     "        f.lastModified = $file_last_modified\n",
     "    \"\"\"\n",
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pub_json = get_publication(\"PRJ-2840\")\n",
+    "pub_json = get_publication(\"PRJ-1811\")\n",
     "\n",
     "with GraphDatabase.driver(URI) as driver:\n",
     "    setup_db(driver)\n",
@@ -195,7 +195,7 @@
     "        description = node_data[\"value\"].get(\"description\", None)\n",
     "        ingest_entity(driver, uuid, title, description, name=name, meta_uuid=meta_uuid)\n",
     "\n",
-    "        file_objs = node_data\n",
+    "        file_objs = node_data[\"value\"].get(\"fileObjs\", [])\n",
     "        for file_info in file_objs:\n",
     "            ingest_file(driver, file_info)\n",
     "            ingest_entity_file_rel(driver, uuid, file_info[\"path\"])"
@@ -231,14 +231,6 @@
     "with GraphDatabase.driver(URI) as driver:\n",
     "    cleanup_db(driver)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60a25230",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds ability to ingest file nodes and create relationships from entity nodes to these files nodes in Neo4j

Added:
**ingest_file()**: Creates or updates a :File node using data from each fileObj identified by its unique path.

**ingest_entity_file_rel()**: Creates :HAS_FILE relationship from node to :File node.

